### PR TITLE
Remove extra new line in song 704

### DIFF
--- a/src/db.json
+++ b/src/db.json
@@ -2621,7 +2621,6 @@
                 ":,: Kun m\u00e4 kuolen, m\u00e4 toivon ett\u00e4",
                 "mut viinikellariin haudataan. :,:",
                 ":,: Viinikellariin - ei ei,",
-                "",
                 "viinikellariin - juu juu,",
                 "viinikellariin haudataan. :,:",
                 "",


### PR DESCRIPTION
![Screenshot_20220923-171355](https://user-images.githubusercontent.com/33721570/191980893-fa8228f5-ee92-4600-b6f3-ccd3f4c7a7a4.jpg)
Extra new line is not in the physical book, in digital one it looks like the screenshot. It was caused by the lyrics extractor not being able to handle  page changes properly